### PR TITLE
DateTimeFormat.formatToParts fixes

### DIFF
--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -249,15 +249,16 @@
         1. Let _tm_ be ToLocalTime(_x_, _dateTimeFormat_.[[calendar]], _dateTimeFormat_.[[timeZone]]).
         1. Let _pattern_ be the value of the _dateTimeFormat_.[[pattern]].
         1. Let _result_ be a new empty List.
-        1. Let _index_ be 0.
         1. Let _beginIndex_ be Call(*%StringProto_indexOf%*, _pattern_, "{", *0*).
         1. Let _endIndex_ be 0.
+        1. Let _nextIndex_ be 0.
+        1. Let _length_ be the number of code units in _pattern_.
         1. Repeat while _beginIndex_ is an integer index into _pattern_:
-        1. Set _endIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _beginIndex_)
+          1. Set _endIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _beginIndex_)
           1. If _endIndex_ is *false*, throw new Error exception.
-          1. If _beginIndex_ is greater than _index_, then:
+          1. If _beginIndex_ is greater than _nextIndex_, then:
             1. Let _separator_ be a new Record.
-            1. Let _separatorValue_ be a substring of _pattern_ from position _index_, inclusive, to position _beginIndex_, exclusive.
+            1. Let _separatorValue_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
             1. Add new part record { [[type]]: "separator", [[value]]: _separatorValue_ } as a new element of the list _result_.
           1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
           1. If _p_ matches a Property column of the row in Table 3, then:
@@ -286,11 +287,11 @@
             1. <emu-note>Unknown token</emu-note>
             1. Let _separatorValue_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
             1. Add new part record { [[type]]: "separtor", [[value]]: _separatorValue_ } as a new element of the list _result_.
-          1. Set _index_ to _endIndex_ + 1.
-          1. Set _beginIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _index_)
-        1. If _endIndex_ is less than _S_, then:
+          1. Set _nextIndex_ to _endIndex_ + 1.
+          1. Set _beginIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _nextIndex_)
+        1. If _nextIndex_ is less than _length_, then:
           1. Let _separator_ to be a new Record.
-          1. Let _separatorValue_ be the substring of _pattern_ from position _endIndex_, exclusive, to position _S_, exclusive.
+          1. Let _separatorValue_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
           1. Add new part record { [[type]]: "separator", [[value]]: _separatorValue_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -234,32 +234,6 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="sec-datetime-formatToParts-functions">
-      <h1>DateTime FormatToParts Functions</h1>
-
-      <p>
-        A DateTime formatToParts function is an anonymous function that optionally takes an argument _date_. It performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _dtf_ be the *this* value.
-        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
-        1. If _date_ is not provided or is *undefined*, then
-          1. Let _x_ be *%Date_now%*().
-        1. Else,
-          1. Let _x_ be ? ToNumber(_date_).
-        1. Return FormatToPartsDateTime(_dtf_, _x_).
-      </emu-alg>
-
-      <emu-note>
-        The function returned by [[Get]] is bound to this DateTimeFormat object so that it can be passed directly to Array.prototype.map or other functions.
-      </emu-note>
-
-      <p>
-        The value of the [[Set]] attribute is *undefined*.
-      </p>
-    </emu-clause>
-
     <emu-clause id="alg-CreateDateTimeParts">
 
       <h1>CreateDateTimeParts(dateTimeFormat, x)</h1>
@@ -557,22 +531,21 @@
     </emu-clause>
 
     <emu-clause id="sec-Intl.DateTimeFormat.prototype.formatToParts">
-      <h1>get Intl.DateTimeFormat.prototype.formatToParts</h1>
+      <h1>Intl.DateTimeFormat.prototype.formatToParts ([ date ])</h1>
 
       <p>
-        Intl.DateTimeFormat.prototype.formatToParts is an accessor property whose set accessor function is *undefined*. Its get accessor function performs the following steps:
+        When the *Intl.DateTimeFormat.prototype.formatToParts* is called with an optional argument _date_, the following steps are taken:
       </p>
 
       <emu-alg>
         1. Let _dtf_ be *this* value.
         1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
-        1. If _dtf_ does not have a [[boundFormatToParts]] internal slot, throw a *TypeError* exception.
-        1. If the [[boundFormatToParts]] internal slot of _dtf_ is *undefined*, then
-          1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-formatToParts-functions"></emu-xref>).
-          1. The value of _F_’s *length* property is 1.
-          1. Let _bf_ be BoundFunctionCreate(_F_, _dft_).
-          1. Set _dtf_.[[boundFormatToParts]] to _bf_.
-        1. Return _dtf_.[[boundFormatToParts]].
+        1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, throw a *TypeError* exception.
+        1. If _date_ is not provided or is *undefined*, then
+          1. Let _x_ be *%Date_now%*().
+        1. Else,
+          1. Let _x_ be ? ToNumber(_date_).
+        1. Return ? FormatDateTimeToParts(_dtf_, _x_).
       </emu-alg>
     </emu-clause>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -234,15 +234,14 @@
       </p>
     </emu-clause>
 
-    <emu-clause id="alg-CreateDateTimeParts">
-
-      <h1>CreateDateTimeParts(dateTimeFormat, x)</h1>
+    <emu-clause id="sec-formatdatetimetoparts" aoid="FormatDateTimeToParts">
+      <h1>FormatDateTimeToParts(dateTimeFormat, x)</h1>
 
       <p>
-        The CreateDateTimeParts abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), and performs the following steps:
+        The *FormatDateTimeToParts* abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), interprets _x_ as a time value as specified in ES2015, 20.3.1.1, and creates the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_. The following steps are taken:
       </p>
 
-      <emu-alg aoid="CreateDateTimeParts">
+      <emu-alg>
         1. If _x_ is not a finite Number, throw a *RangeError* exception.
         1. Let _locale_ be the value of _dateTimeFormat_.[[locale]].
         1. Let _nf_ be ? Construct(%NumberFormat%, « [locale], {useGrouping: *false*} »).
@@ -297,10 +296,6 @@
       </emu-alg>
 
       <emu-note>
-        CreateDateTimeParts abstract operation interpretes _x_ as a time value as specified in ES2015, 20.3.1.1; and create the corresponding parts according to the effective locale and the formatting options of _dateTimeFormat_.
-      </emu-note>
-
-      <emu-note>
         It is recommended that implementations use the locale and calendar dependent strings provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>), and use CLDR "abbreviated" strings for DateTimeFormat "short" strings, and CLDR "wide" strings for DateTimeFormat "long" strings.
       </emu-note>
 
@@ -310,8 +305,7 @@
 
     </emu-clause>
 
-    <emu-clause id="alg-FormatDateTime" aoid="DateTimeFormat">
-
+    <emu-clause id="sec-formatdatetime" aoid="FormatDateTime">
       <h1>FormatDateTime(dateTimeFormat, x)</h1>
 
       <p>
@@ -319,35 +313,10 @@
       </p>
 
       <emu-alg>
-        1. Let _parts_ be CreateDateTimeParts(_dateTimneFormat_, _x_).
-        1. Let _result_ be an empty string.
+        1. Let _parts_ be FormatDateTimeToParts(_dateTimeFormat_, _x_).
+        1. Let _result_ be an empty String.
         1. For each _part_ in _parts_, do:
           1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[value]].
-        1. Return _result_.
-      </emu-alg>
-
-    </emu-clause>
-
-    <emu-clause id="alg-FormatToPartDateTime" aoid="DateTimeFormatToParts">
-
-      <h1>FormatToPartDateTime(dateTimeFormat, x)</h1>
-
-      <p>
-        The FormatToPartDateTime abstract operation is called with arguments _dateTimeFormat_ (which must be an object initialized as a DateTimeFormat) and _x_ (which must be a Number value), and performs the following steps:
-      </p>
-
-      <emu-alg>
-        1. Let _parts_ be CreateDateTimeParts(_dateTimneFormat_, _x_).
-        1. Let _result_ be ArrayCreate(0).
-        1. Let _n_ be 0.
-        1. For each _part_ in _parts_, do:
-          1. Let _O_ be ObjectCreate(%ObjectPrototype%).
-          1. Let _typeDesc_ be the PropertyDescriptor{[[Value]]: _part_.[[type]], [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
-          1. Perform ? DefinePropertyOrThrow(_O_, "type", _typeDesc_).
-          1. Let _valueDesc_ be the PropertyDescriptor{[[Value]]: _part_.[[value]], [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
-          1. Perform ? DefinePropertyOrThrow(_O_, "value", _valueDesc_).
-          1. Perform ? CreateDataProperty(_result_, ? ToString(_n_), _O_).
-          1. Increment _n_ by 1.
         1. Return _result_.
       </emu-alg>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -257,9 +257,8 @@
           1. Set _endIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _beginIndex_)
           1. If _endIndex_ is *false*, throw new Error exception.
           1. If _beginIndex_ is greater than _nextIndex_, then:
-            1. Let _separator_ be a new Record.
-            1. Let _separatorValue_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
-            1. Add new part record { [[type]]: "separator", [[value]]: _separatorValue_ } as a new element of the list _result_.
+            1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
+            1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
           1. Let _p_ be the substring of _pattern_ from position _beginIndex_, exclusive, to position _endIndex_, exclusive.
           1. If _p_ matches a Property column of the row in Table 3, then:
             1. Let _f_ be the value of the [[<_p_>]] internal slot of _dateTimeFormat_.
@@ -282,17 +281,15 @@
               1. Let _fv_ be an implementation and locale dependent String value representing "post meridiem";
             1. Else,
               1. Let _fv_ be an implementation and locale dependent String value representing "ante meridiem".
-            1. Add new part record { [[type]]: "dayperiod", [[value]]: _fv_ } as a new element of the list _result_.
+            1. Add new part record { [[type]]: *"dayPeriod"*, [[value]]: _fv_ } as a new element of the list _result_.
           1. Else,
-            1. <emu-note>Unknown token</emu-note>
-            1. Let _separatorValue_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
-            1. Add new part record { [[type]]: "separtor", [[value]]: _separatorValue_ } as a new element of the list _result_.
+            1. Let _literal_ be the substring of _pattern_ from position _beginIndex_, inclusive, to position _endIndex_, inclusive.
+            1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
           1. Set _nextIndex_ to _endIndex_ + 1.
           1. Set _beginIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _nextIndex_)
         1. If _nextIndex_ is less than _length_, then:
-          1. Let _separator_ to be a new Record.
-          1. Let _separatorValue_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
-          1. Add new part record { [[type]]: "separator", [[value]]: _separatorValue_ } as a new element of the list _result_.
+          1. Let _literal_ be the substring of _pattern_ from position _nextIndex_, inclusive, to position _length_, exclusive.
+          1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.
         1. Return _result_.
       </emu-alg>
 

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -254,7 +254,7 @@
         1. Let _length_ be the number of code units in _pattern_.
         1. Repeat while _beginIndex_ is an integer index into _pattern_:
           1. Set _endIndex_ to Call(*%StringProto_indexOf%*, _pattern_, "}", _beginIndex_)
-          1. If _endIndex_ is *false*, throw new Error exception.
+          1. If _endIndex_ = -1, throw new Error exception.
           1. If _beginIndex_ is greater than _nextIndex_, then:
             1. Let _literal_ be a substring of _pattern_ from position _nextIndex_, inclusive, to position _beginIndex_, exclusive.
             1. Add new part record { [[type]]: *"literal"*, [[value]]: _literal_ } as a new element of the list _result_.

--- a/spec/datetimeformat.html
+++ b/spec/datetimeformat.html
@@ -119,7 +119,6 @@
           1. Let _pattern_ be Get(_bestFormat_, *"pattern"*).
         1. Set _dateTimeFormat_.[[pattern]] to _pattern_.
         1. Set _dateTimeFormat_.[[boundFormat]] to *undefined*.
-        1. Set _dateTimeFormat_.[[boundFormatToParts]] to *undefined*.
         1. Set _dateTimeFormat_.[[initializedDateTimeFormat]] to *true*.
         1. Return _dateTimeFormat_.
       </emu-alg>
@@ -311,7 +310,7 @@
       </p>
 
       <emu-alg>
-        1. Let _parts_ be FormatDateTimeToParts(_dateTimeFormat_, _x_).
+        1. Let _parts_ be ? FormatDateTimeToParts(_dateTimeFormat_, _x_).
         1. Let _result_ be an empty String.
         1. For each _part_ in _parts_, do:
           1. Set _result_ to a String value produced by concatenating _result_ and _part_.[[value]].
@@ -487,11 +486,11 @@
 
       <emu-alg>
         1. Let _dtf_ be *this* value.
-        1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
-        1. If _dtf_ does not have a [[boundFormat]] internal slot, throw a *TypeError* exception.
+        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
         1. If the [[boundFormat]] internal slot of _dtf_ is *undefined*, then
           1. Let _F_ be a new built-in function object as defined in DateTime Format Functions (<emu-xref href="#sec-datetime-format-functions"></emu-xref>).
           1. Let _bf_ be BoundFunctionCreate(_F_, _dft_).
+          1. Perform ! DefinePropertyOrThrow(_bf_, `"length"`, PropertyDescriptor {[[Value]]: 1, [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true*}).
           1. Set _dtf_.[[boundFormat]] to _bf_.
         1. Return _dtf_.[[boundFormat]].
       </emu-alg>
@@ -506,8 +505,7 @@
 
       <emu-alg>
         1. Let _dtf_ be *this* value.
-        1. If Type(_dtf_) is not Object, throw a *TypeError* exception.
-        1. If _dtf_ does not have an [[initializedDateTimeFormat]] internal slot, throw a *TypeError* exception.
+        1. Assert: Type(_dtf_) is Object and _dtf_ has an [[initializedDateTimeFormat]] internal slot whose value is *true*.
         1. If _date_ is not provided or is *undefined*, then
           1. Let _x_ be *%Date_now%*().
         1. Else,


### PR DESCRIPTION
The following changes are meant to unify the style of the `DateTimeFormat.formatToParts` proposal (https://github.com/tc39/ecma402/pull/64) with `NumberFormat.formatToParts` (https://github.com/tc39/ecma402/pull/79).

The biggest change is that `DateTimeFormat.formatToParts`is now a method defined on the prototype instead of being an accessor returning a function bound to the formatter instance.  I also renamed the `CreateDateTimeParts` abstract operation to `FormatDateTimeToParts` to make it consistent with the existing `FormatDateTime` operation;  and I renamed `separator` to `literal` following the discussion in https://github.com/tc39/ecma402/issues/30.

A number of other editorial fixes are also included.

cc @caridy
